### PR TITLE
Fix issues on Brazilian Portuguese translation

### DIFF
--- a/App Media-Assets/langs/17/lang.ini
+++ b/App Media-Assets/langs/17/lang.ini
@@ -21,7 +21,6 @@ STR_NOT_FOUND=String não encontrada
 
 #strings STORE
 [STORE]
-
 BETA_REVOKED=O BETA terminou ou foi revogado, altere seu CDN
 BETA_LOGGED_IN=Você fez login como um usuário beta
 INERNET_REQ=Conexão com a Internet é necessária
@@ -41,7 +40,7 @@ STORE_VER=Versão da Loja:
 SYS_VER=Versão do sistema:
 HB_GAME=Jogo Homebrew
 EMU=Emulador
-EMU_ADDON=Complemento do emulador
+EMU_ADDON=Complemento de emulador
 MEDIA=Mídia
 PLUGINS=Plugins do paylod Mira
 UTLIITY=Utilitário
@@ -50,7 +49,7 @@ DL=Baixar
 INSTALL=Instalar
 INSTALLING=Instalando
 SAPPS=Aplicativos da Loja
-IAPPS=Aplicativos da Loja
+IAPPS=Aplicativos instalados
 STRG=Grupos da Loja
 RINSTALL=Pronto para instalar
 QUEUE=Fila
@@ -116,14 +115,16 @@ ERROR_DL_ASSETS=NÃO foi possível baixar o recurso:
 SEARCHING=Procurando....
 SETTINGS_1=Rede de entrega de conteúdo
 SETTINGS_2=Caminho Temporário
-SETTINGS_3=Atualizar database da Loja
 SETTINGS_4=Caminho do .INI
-SETTINGS_5=Caminho da fonte personalizada
-SETTINGS_6=Instalação Automática
 SETTINGS_7=Limpar imagens em cache
-SETTINGS_8=Mostrar progresso da instalação
-SETTINGS_9=Restaurar Configurações da Loja
 SETTINGS_10=Salvar Configurações
+#UPDATED STRINGS
+SETTINGS_5=Pré carregar icones em cache na inicialização
+SETTINGS_3=Recarregar banco de dados da loja
+SETTINGS_9=Resetar configurações da loja
+SETTINGS_6=Instalar automaticamente
+SETTINGS_8=Progresso de Instalação legado
+#NEW STRINGS
 AUTO_FAILURE_ERROR=Progresso de Instalação legado precisa ser Desligado para ativar essa configuração
 INSTALL_PROG_ERROR=Instalação Automática precisa ser Desligada para ativar essa configuração
 CANCEL=Cancelar
@@ -134,10 +135,10 @@ INSTALL_2=Instalar
 APP_UPDATE_AVAIL=Atualização Disponível
 UPDATE_NOW=Atualizar Agora
 REINSTALL_APP=Reinstalar Ultima
-CHECKING_FOR_UPDATES=Tarkistetaan päivityksiä...
-PRE_LOADING_CACHE=ladataan valmiiksi välimuistissa olevia sovelluskuvakkeita...
-PRE_LOAD_SETTING=Esilataa välimuistiin tallennetut kuvakkeet käynnistyksen yhteydessä
-UPDATES_STILL_LOADING=Päivitykset tarkistetaan edelleen taustalla
-SHOW_PROG=Näytä edistyminen
-STAY_IN_BACKGROUND=Pysy taustalla
-INSTALL_COMPLETE=Asennus valmis!...
+CHECKING_FOR_UPDATES=Procurando atualizações...
+PRE_LOADING_CACHE=pré carregando ícones de apps em cache...
+PRE_LOAD_SETTING=Pré carregar ícones em cache na inicialização
+UPDATES_STILL_LOADING=As atualizações ainda estão sendo verificadas em segundo plano
+SHOW_PROG=Mostrar Progresso
+STAY_IN_BACKGROUND=Continuar em Segundo Plano
+INSTALL_COMPLETE=Instalação Completa!


### PR DESCRIPTION
Hello LightningMods! 
This commit as the title implies, fixes some issues on the Brazilian Portuguese translation, primarly with some of the text being in Finnish as shown here:

![image](https://github.com/user-attachments/assets/efc588ae-556a-49ed-8519-c068fca3c1e2) 

The other fixes are a rebase to the update main lang.ini file

P.S: If this file isn't the Brazilian Portuguese file, please point me to the right one. I think it's the correct one because my PS4 is in Brazilian Portuguese and the store has the translation issues i fixed.